### PR TITLE
Fix description of `KaType.upperBoundIfFlexible` and `KaType.lowerBoundIfFlexible`

### DIFF
--- a/Writerside/topics/KaType.md
+++ b/Writerside/topics/KaType.md
@@ -60,10 +60,10 @@ type because it may be unknown if this type can accept `null`.
 ordinary calls are valid on it.
 
 `fun KaType.upperBoundIfFlexible(): KaType`
-: Returns the upper bound if the given type is a flexible type, and `null` otherwise.
+: Returns the upper bound if the given type is a flexible type, and the given type itself otherwise.
 
 `fun KaType.lowerBoundIfFlexible(): KaType`
-: Returns the lower bound if the given type is a flexible type, and `null` otherwise.
+: Returns the lower bound if the given type is a flexible type, and the given type itself otherwise.
 
 ## Type relation utilities
 


### PR DESCRIPTION
According to
https://github.com/JetBrains/kotlin/blob/2.1.0/analysis/analysis-api/src/org/jetbrains/kotlin/analysis/api/components/KaTypeProvider.kt#L106-L112

```
    public fun KaType.upperBoundIfFlexible(): KaType = withValidityAssertion {
        (this as? KaFlexibleType)?.upperBound ?: this
    }

    public fun KaType.lowerBoundIfFlexible(): KaType = withValidityAssertion {
        (this as? KaFlexibleType)?.lowerBound ?: this
    }
```

instead of `null` they return the given type itself.