### PR TITLE
Fix IntelliJ IDEA version where K2 mode is the default

### DIFF
--- a/Writerside/topics/Testing-in-K1-Locally.md
+++ b/Writerside/topics/Testing-in-K1-Locally.md
@@ -1,8 +1,8 @@
 # Testing in K1 Locally
 
-From IntelliJ IDEA version 2025.3, K2 mode is the default. If you need to test the plugin in K1 mode locally, pass the -Didea.kotlin.plugin.use.k1=true VM option to the IntelliJ IDEA run configuration or to the test task.
+From IntelliJ IDEA version 2025.1, K2 mode is the default. If you need to test the plugin in K1 mode locally, pass the -Didea.kotlin.plugin.use.k1=true VM option to the IntelliJ IDEA run configuration or to the test task.
 
-> If you use IntelliJ IDEA version 2025.2 or older, use -Didea.kotlin.plugin.use.k2=true to enable K2 mode.
+> If you use IntelliJ IDEA version 2024.3 or older, use -Didea.kotlin.plugin.use.k2=true to enable K2 mode.
 
 When using the [IntelliJ Platform Gradle Plugin](https://github.com/JetBrains/intellij-platform-gradle-plugin), you can specify the option directly in the `build.gradle.kts`
 file.


### PR DESCRIPTION
Hello! It seems that the version of Intellij IDEA when the K2 compiler was enabled by default is incorrect in the documentation: from different sources it says 2025.1, not 2025.3 (e.g. see [release notes for IntelliJ IDEA 2025.1](https://www.jetbrains.com/idea/whatsnew/2025-1/#page__content-key-highlights) or [K2 Mode in IntelliJ IDEA 2025.1: Current State and FAQ](https://blog.jetbrains.com/idea/2025/04/k2-mode-in-intellij-idea-2025-1-current-state-and-faq/))