### PR TITLE
docs: fix typos and grammar in API documentation

### DIFF
--- a/Writerside/topics/KaType.md
+++ b/Writerside/topics/KaType.md
@@ -1,6 +1,6 @@
 # KaType
 
-Represents a Kotlin type. It serves as the base interface for various specific type.
+Represents a Kotlin type. It serves as the base interface for various specific types.
 
 ## Hierarchy
 
@@ -55,7 +55,7 @@ type because it may be unknown if this type can accept `null`.
 
 `val KaType.hasFlexibleNullability: Boolean`
 : `true` if the given type is a flexible
-([platform](https://kotlinlang.org/docs/java-interop.html#null-safety-and-platform-types)) type, can both safe and
+([platform](https://kotlinlang.org/docs/java-interop.html#null-safety-and-platform-types)) type, i.e., both safe and
 ordinary calls are valid on it.
 
 `fun KaType.upperBoundIfFlexible(): KaType`
@@ -67,16 +67,16 @@ ordinary calls are valid on it.
 ## Type relation utilities
 
 `fun KaType.semanticallyEquals(other: KaType, errorTypePolicy: KaSubtypingErrorTypePolicy = KaSubtypingErrorTypePolicy.STRICT): Boolean`
-: Check semantic type equality. Returns `true` if the given type can be used instead of `other`.
+: Checks semantic type equality. Returns `true` if the given type can be used instead of `other`.
 
 `fun KaType.isSubtypeOf(supertype: KaType, errorTypePolicy: KaSubtypingErrorTypePolicy = KaSubtypingErrorTypePolicy.STRICT): Boolean`
-: Check if the given type is a subtype of the `supertype`.
+: Checks if the given type is a subtype of the `supertype`.
 
 `fun KaType.isClassType(classId: ClassId): Boolean`
 : `true` if the given type is a class type with the given `ClassId`, or its nullable version.
 
 `fun KaType.hasCommonSubtypeWith(that: KaType): Boolean`
-: Check whether the given type is compatible with the other type. Compatibility means the types can have a common subtype.
+: Checks whether the given type is compatible with the other type. Compatibility means the types can have a common subtype.
 
 `val KaType.directSupertypes: Sequence<KaType>`
 : Direct super types of the given type. For example, for `MutableList<String>` it will be `List<String>` and
@@ -136,8 +136,8 @@ ordinary calls are valid on it.
 ## Scope utilities
 
 `val KaType.scope: KaTypeScope?`
-: Return a `KaTypeScope` for a given type. The type scope includes all members which are declared and callable on a given type.
-: Comparing to a `KaScope`, in the `KaTypeScope` all use-site type parameters are substituted.
+: Returns a `KaTypeScope` for a given type. The type scope includes all members which are declared and callable on a given type.
+: Compared to a `KaScope`, in the `KaTypeScope` all use-site type parameters are substituted.
 : **Experimental API**.
 
 `val KaType.syntheticJavaPropertiesScope: KaTypeScope?`
@@ -171,5 +171,5 @@ example of a non-denotable type.
 : **Experimental API**.
 
 `fun KaType.render(renderer: KaTypeRenderer = KaTypeRendererForSource.WITH_QUALIFIED_NAMES, position: Variance): String`
-: Render the given type to a `String`. The particular rendering strategy is defined by the `renderer`.
+: Renders the given type to a `String`. The particular rendering strategy is defined by the `renderer`.
 : **Experimental API**.

--- a/Writerside/topics/Symbols.md
+++ b/Writerside/topics/Symbols.md
@@ -30,7 +30,7 @@ While a `KtCallableDeclaration` can provide the declared type of a function or p
 **resolved type**, which takes into account imports, aliases, and other parts of the lexical context.
 
 In the following function, the PSI can only say that the `text` parameter has some type called `String`, while the
-The Analysis API can check that it indeed is `kotlin.String`, and not something like `my.app.String`.
+the Analysis API can check that it indeed is `kotlin.String`, and not something like `my.app.String`.
 
 ```Kotlin
 fun print(text: String) {}

--- a/Writerside/topics/TypeCreatorMigrationGuide.md
+++ b/Writerside/topics/TypeCreatorMigrationGuide.md
@@ -38,7 +38,7 @@ analyze(ktFile) {
 }
 ```
 
-Here we are trying to contruct a class type for `kotlin.Pair<A, B>`.
+Here we are trying to construct a class type for `kotlin.Pair<A, B>`.
 It requires two type arguments; however, we haven't provided any.
 `buildClassType(pairClassId)` constructs an incorrect type `Pair` that has no type arguments.
 Note that this type is valid from the Analysis API perspective, i.e., it's not `KaErrorType`, however,


### PR DESCRIPTION
## Summary

Fix 10 issues across 3 documentation files:

- Fix contruct → construct
- Fix grammar in hasFlexibleNullability description
- Fix Kotlin doc convention (Check→Checks, Return→Returns)

No functional changes — documentation only.